### PR TITLE
Allow PAS plugin loading to continue in debug mode (development)

### DIFF
--- a/docs/CHANGES.txt
+++ b/docs/CHANGES.txt
@@ -1,8 +1,8 @@
 2.3.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Allow PAS plugin loading to continue in debug mode (development) with an error warning if the kerberos library cannot be loaded on unix.
+  [fredvd]
 
 2.3.1 (2014-07-04)
 ------------------

--- a/netsight/windowsauthplugin/plugin.py
+++ b/netsight/windowsauthplugin/plugin.py
@@ -4,6 +4,8 @@
 from AccessControl.SecurityInfo import ClassSecurityInfo
 from App.class_init import default__class_init__ as InitializeClass
 
+from Globals import DevelopmentMode
+
 from Products.PluggableAuthService.plugins.BasePlugin import BasePlugin
 from Products.PluggableAuthService.utils import classImplements
 
@@ -21,8 +23,14 @@ else:
 if WINDOWS:
     import sspi, sspicon
 else:
-    import kerberos
-    from kerberos import GSSError
+    try:
+        import kerberos
+        from kerberos import GSSError
+    except ImportError:
+        LOG("SPNEGO Plugin", ERROR, "No Kerberos system library present.")
+        if not DevelopmentMode:
+            # Fail explicit in production mode
+            raise
 
 import interface
 


### PR DESCRIPTION
When we have a project with netsight.windowsauthplugin and try to run the Data.fs locally we get pickling errors on the PAS plugin if the python source is not present, but if we add netsight.windowsauthplugin Zope won't start unless we have pykerberos or python-kerberos installed, which needs a kerberos install on developer machines. :-S

this PR allows to load the plugin when debug is on (development mode) with an ERROR issued to stdout. in production mode Zope will still raise an import error without kerberos present. 