### PR TITLE
Recommend adjusting the 'http-header-max-length' ZServer instance option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,6 +43,16 @@ Integrated Windows Authentication, IE will attempt to construct a SPN
 based upon resolving the hostname to an A record. Hence to avoid
 problems, do not use CNAMEs for your DNS records.
 
+Request Header Limitations
+--------------------------
+
+Some web server components including Zope's own ZServer impose
+limitations on the request and response header lengths.
+
+When using SSO it's recommended to increase ``http-header-max-length``
+to 16384.
+
+
 Service Principal Names (SPNs) and Keytabs
 ------------------------------------------
 


### PR DESCRIPTION
In the wild I have seen requests just over the default 8192 bytes.

And the logging message from Medusa is at DEBUG level so you'll never know what hit you.
